### PR TITLE
Multi sort component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
   ],
   "rules": {
     "@next/next/no-img-element": 1,
+    "@tanstack/query/no-rest-destructuring": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "no-unused-vars": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,9 @@
     "activityBar.activeBorder": "#d5e9de"
   },
   "prisma.pinToPrisma6": true,
+  "eslint.useFlatConfig": false,
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "eslint.run": "onType",
   "search.exclude": {
     "**/node_modules": true,
     "**/.cursor": true,

--- a/app/(base)/test/_components/MultiSortDemo.tsx
+++ b/app/(base)/test/_components/MultiSortDemo.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import Typography from '@/components/typography/Typography';
+import ColumnStack from '@/shared/components/ColumnStack';
+import MultiSortSelect from '@/shared/multi-sort/MultiSortSelect';
+import useMultiSortValues from '@/shared/multi-sort/useMultiSortValues';
+import { getFakeSortedSearchQueryOptions } from '@/shared/multi-sort/multi-sort.query';
+
+export default function MultiSortDemo() {
+  const { sortConfig, searchParamsString } = useMultiSortValues();
+
+  const { data, isFetching } = useQuery(getFakeSortedSearchQueryOptions(sortConfig, searchParamsString));
+
+  return (
+    <ColumnStack className="w-full gap-y-4">
+      <ColumnStack className="gap-y-1">
+        <Typography variant="h6">Multi sort</Typography>
+        <MultiSortSelect maxWidth="24rem" />
+      </ColumnStack>
+
+      <ColumnStack className="gap-y-1">
+        <Typography variant="label0">Raw SortConfig array:</Typography>
+        <Typography variant="code0" as="pre" className="rounded-md bg-muted p-2">
+          { JSON.stringify(sortConfig, null, 2) }
+        </Typography>
+      </ColumnStack>
+
+      <ColumnStack className="gap-y-1">
+        <Typography variant="label0">URLSearchParams string:</Typography>
+        <Typography variant="code0" as="pre" className="rounded-md bg-muted p-2 break-all whitespace-pre-wrap">
+          { searchParamsString }
+        </Typography>
+      </ColumnStack>
+
+      <ColumnStack className="gap-y-1">
+        <Typography variant="label0">Fake GET request (TanStack Query):</Typography>
+        { isFetching ?
+          <Typography variant="nodata1">Fetching...</Typography>
+        : <Typography variant="code0" as="pre" className="rounded-md bg-muted p-2 break-all whitespace-pre-wrap">
+            { data?.requestUrl }
+          </Typography>
+        }
+      </ColumnStack>
+    </ColumnStack>
+  );
+}

--- a/app/(base)/test/page.tsx
+++ b/app/(base)/test/page.tsx
@@ -1,5 +1,5 @@
+import MultiSortDemo from './_components/MultiSortDemo';
 import NestedRequest from './_components/NestedRequest';
-import ScreenSizeDisplay from './_components/ScreenSizeDisplay';
 
 interface PlaygroundPageProps {
   params: Promise<{ slug: string }>;
@@ -9,6 +9,7 @@ interface PlaygroundPageProps {
 export default function PlaygroundPage({}: PlaygroundPageProps) {
   return (
     <div className="flex w-full flex-col items-start justify-start gap-y-3">
+      <MultiSortDemo />
       <NestedRequest />
     </div>
   );

--- a/components/typography/Typography.tsx
+++ b/components/typography/Typography.tsx
@@ -82,24 +82,23 @@ export const typographyVariants = cva('scroll-m-20', {
 export interface TypographyProps extends React.HTMLAttributes<HTMLElement>, VariantProps<typeof typographyVariants> {
   as?: React.ElementType;
   children?: ReactNode;
+  ref?: React.Ref<HTMLElement>;
 }
 
 export default function Typography({ children, variant = 'body1', as, className, ...props }: TypographyProps) {
-  if (intrinsicElements.includes(variant ?? '')) {
-    const Tag = as || (variant as intrinsicElementType) || 'p';
+  const Tag: React.ElementType = as ?? (isIntrinsicVariant(variant) ? variant : 'span');
 
-    return (
-      <Tag className={ cn(typographyVariants({ variant: variant, className: className })) } { ...props }>
-        { children }
-      </Tag>
-    );
-  }
   return (
-    <p className={ cn(typographyVariants({ variant: variant, className: className })) } { ...props }>
+    <Tag className={ cn(typographyVariants({ variant: variant, className: className })) } { ...props }>
       { children }
-    </p>
+    </Tag>
   );
 }
 
-const intrinsicElements = ['h1', 'h2', 'h3', 'h4', 'h5', 'p'];
-type intrinsicElementType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
+// h6 intentionally left out: it renders as a span for now
+const intrinsicVariants = ['h1', 'h2', 'h3', 'h4', 'h5', 'p'] as const;
+type IntrinsicVariant = (typeof intrinsicVariants)[number];
+
+function isIntrinsicVariant(variant: TypographyProps['variant']): variant is IntrinsicVariant {
+  return intrinsicVariants.includes(variant as IntrinsicVariant);
+}

--- a/components/typography/Typography.tsx
+++ b/components/typography/Typography.tsx
@@ -47,6 +47,10 @@ export const typographyVariants = cva('scroll-m-20', {
       p1: `text-[0.875rem] leading-5 tracking-normal`,
       p2: `text-[1rem] leading-6 tracking-normal`,
 
+      span0: `text-[0.75rem] leading-4 tracking-normal`,
+      span1: `text-[0.875rem] leading-5 tracking-normal`,
+      span2: `text-[1rem] leading-6 tracking-normal`,
+
       caption0: `text-[0.65rem] leading-[0.9rem] tracking-wide text-gray-500 dark:text-gray-300`,
       caption1: `text-[0.75rem] leading-4 tracking-wide text-gray-500 dark:text-gray-300`,
       caption2: `text-[0.85rem] leading-5 tracking-normal text-gray-500 dark:text-gray-300`,
@@ -111,8 +115,9 @@ function getDefaultTag(variant: TypographyProps['variant']): React.ElementType {
   if (isIntrinsicVariant(variant)) {
     return variant;
   }
-  if (variant === 'p0' || variant === 'p1' || variant === 'p2') {
-    return 'p';
+  if (variant === 'h6' || variant === 'span0' || variant === 'span1' || variant === 'span2') {
+    return 'span';
   }
-  return 'span';
+  // the app historically renders every other variant as a <p>
+  return 'p';
 }

--- a/components/typography/Typography.tsx
+++ b/components/typography/Typography.tsx
@@ -43,6 +43,10 @@ export const typographyVariants = cva('scroll-m-20', {
 
       p: `text-[0.875rem] leading-5 tracking-normal [&:not(:first-child)]:mt-6`,
 
+      p0: `text-[0.75rem] leading-4 tracking-normal`,
+      p1: `text-[0.875rem] leading-5 tracking-normal`,
+      p2: `text-[1rem] leading-6 tracking-normal`,
+
       caption0: `text-[0.65rem] leading-[0.9rem] tracking-wide text-gray-500 dark:text-gray-300`,
       caption1: `text-[0.75rem] leading-4 tracking-wide text-gray-500 dark:text-gray-300`,
       caption2: `text-[0.85rem] leading-5 tracking-normal text-gray-500 dark:text-gray-300`,
@@ -86,7 +90,7 @@ export interface TypographyProps extends React.HTMLAttributes<HTMLElement>, Vari
 }
 
 export default function Typography({ children, variant = 'body1', as, className, ...props }: TypographyProps) {
-  const Tag: React.ElementType = as ?? (isIntrinsicVariant(variant) ? variant : 'span');
+  const Tag: React.ElementType = as ?? getDefaultTag(variant);
 
   return (
     <Tag className={ cn(typographyVariants({ variant: variant, className: className })) } { ...props }>
@@ -101,4 +105,14 @@ type IntrinsicVariant = (typeof intrinsicVariants)[number];
 
 function isIntrinsicVariant(variant: TypographyProps['variant']): variant is IntrinsicVariant {
   return intrinsicVariants.includes(variant as IntrinsicVariant);
+}
+
+function getDefaultTag(variant: TypographyProps['variant']): React.ElementType {
+  if (isIntrinsicVariant(variant)) {
+    return variant;
+  }
+  if (variant === 'p0' || variant === 'p1' || variant === 'p2') {
+    return 'p';
+  }
+  return 'span';
 }

--- a/plans/multi-sorter/plan.md
+++ b/plans/multi-sorter/plan.md
@@ -1,0 +1,71 @@
+# Objective
+
+- Create a standalone multi-sort configuration component.
+- This component will not be used in this application, so do not make this with any of the specifics in this app, it could be used here, but this should also work anywhere else in other repos by a drop in or components / store copy paste.
+- gist of this is that when sort options are checked/unchecked, dragged. these changes are stored in the zustand table-sort store, persisted in the localstorage, then when selecting it via a selector.
+
+# Specs
+
+- table-sort.ts. is already created with placeholder and other constants for use.
+- This component should let user click on it and show a dropdown menu to click to check to turn on a sort, and checked sort options can be dragged vertically to determine the order of the sort.
+- When this component is not "opened" it should be a combobox with multiple turned on. This is so that a user can easily remove a sort option by clicking the "x" clear button in the combobox.
+- Then a user click this combobox to open, it should show a dropdown menu. Then it should display the SORT_ORDER_OPTIONS vertically, the displayed name should be using the SortOptionDisplayMap.
+- There should be a checkbox to the left of the option, we want the user to be able to click the checkbox to add this menu option as part of the sort array. Thus, don't trigger a actual select effect when the menu item is clicked, matter of fact, the menu item display name should not fire any events when clicked. It's just text. this dropdown menu should only be closed when clicked outside. the user will be clicking the checkbox to add this sort to the sort list.
+- Once a menu item is checked, the display sort of these menu items should show the "checked" items first, from the top. This will be important because the next step.
+- For the options that are checked, they should have a draggable icon grip-vertical (lucide) shown at the most right-end of the menu item display. This should allow the user to drag the menu item within the area of only menu items that are checked. Dragging an item below items that are not checked should just put that item at the end of all checked items, because the unchecked items is not a droppable zone.
+- The available options are already stated in table-sort.ts. There are also zustand store stuff and settings already created as a placeholder.
+- The default sort array is listed in there, so when a user opens the dropdown, that default one should be showing already. DEFAULT_SORT_OPTION should always be checked, users should not be able to uncheck that default one. Don't hardcode the actual values when working these logic because DEFAULT_SORT_OPTION can be swapped to something else in the future.
+- When a user checks or drags (working) in this dropdown menu, do not fire off zustand updates for every change. Fire off the zustand store update to currentSort when the dropdown menu is closed. this indicates the user has finished.
+- put a small label on top of the dropdown menu when opened: that conveys to user that this is the sort order for multiple sorts of columns.
+- if another item (more than 1, the 1 being the default sort option) is checked, display a button (or dropdown menu item), that looks nice as part of this dropdown menu that lets user to clear all but the default when clicked.
+- then via a hook, user can get the sort array in the order the user has ordered, and there should be 2 options when getting this value. one is the raw SortConfig array, the other is a string in the format of URLSearchParam string, so it could look like search?sort=arrival_date&sort=status&sort=user_id&direction=asc&direction=asc&direction=desc (as an example). so i should be able to call a hook and get those 2 values returned.
+- for persistence, setCurrentSort in the zustand should be saved in the localstorage.
+- one option i want to add is that, add a prop in the component (Wherever it should be), that is "fireChangeOnClose", set this to true by default. this is that if true, then only update zustand store to make changes if user closed the dropdown menu. If this is false, then update the zustand store on every check and drag.
+- this combobox should show each sort option as their display name, and its sort direction (asc or desc). this combobox's max width should be customizable, so the display is longer, then truncate ellipses it. 
+- when done, put this in the /app(base)/test page so i can see it in action.
+
+
+# Test
+
+- to verify this is working: an sort array of
+
+```js
+const arr = [
+  {
+    field: 'arrival_date',
+    direction: 'asc',
+  },
+   {
+    field: 'user_id',
+    direction: 'desc',
+  },
+   {
+    field: 'status',
+    direction: 'desc',
+  },
+];
+```
+
+should produce the following search param string:
+
+```js
+ search?sort=arrival_date&sort=user_id&sort=status&direction=asc&direction=desc&direction=desc 
+ ```
+
+Each of the items in that array is displayed in the string with the sort key, in ORDER. then the direction is then displayed in that string in ORDER.
+
+
+# Details
+
+- Use shadcn components
+- for drag and drop, use @hello-pangea/dnd library.
+- all displays should be in its file.
+- all work should be componentized, with props if needed.
+- this should be customizable, for example className prop can be passed in to change things if need to be with cn() util function.
+- this component should be in its own sub folder in /shared. So it is easily portable.
+- use hooks and create hooks as needed (prefer custom hooks the most)
+
+
+# Extra
+
+- Create a new tanstack query action file, that uses the hook we created above to get the 2 values (array and searchparams string). then use this the search param string to be part of a fake (example) GET request API URL. like:  search?sort=arrival_date&sort=user_id&sort=status&direction=asc&direction=desc&direction=desc 

--- a/shared/multi-sort/MultiSortMenu.tsx
+++ b/shared/multi-sort/MultiSortMenu.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { ListX } from 'lucide-react';
+import { Draggable, Droppable, DragDropContext, type DropResult } from '@hello-pangea/dnd';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import Typography from '@/components/typography/Typography';
+import { SortConfig, SortOptions } from '@/store/sorter/table-sort';
+
+import MultiSortMenuItem from './MultiSortMenuItem';
+import { reorderList, getUncheckedOptions } from './multi-sort.utils';
+
+const DROPPABLE_ID = 'multi-sort-checked-options';
+
+interface MultiSortMenuProps {
+  sort: SortConfig[];
+  options: SortOptions[];
+  displayMap: Record<SortOptions, string>;
+  defaultOption: SortOptions;
+  onSortChange: (sort: SortConfig[]) => void;
+  label?: string;
+  className?: string;
+}
+
+export default function MultiSortMenu({
+  sort,
+  options,
+  displayMap,
+  defaultOption,
+  onSortChange,
+  label = 'Sort order. Columns are sorted top to bottom.',
+  className,
+}: MultiSortMenuProps) {
+  const uncheckedOptions: SortOptions[] = getUncheckedOptions(sort, options);
+  const hasExtraChecked: boolean = sort.length > 1;
+
+  function handleCheckedChange(option: SortOptions, checked: boolean) {
+    if (option === defaultOption && !checked) {
+      return;
+    }
+
+    if (checked) {
+      onSortChange([...sort, { field: option, direction: 'asc' }]);
+    } else {
+      onSortChange(sort.filter((config) => config.field !== option));
+    }
+  }
+
+  function handleDirectionToggle(option: SortOptions) {
+    onSortChange(
+      sort.map((config) => {
+        if (config.field !== option) {
+          return config;
+        }
+        return { ...config, direction: config.direction === 'desc' ? 'asc' : 'desc' };
+      }),
+    );
+  }
+
+  function handleDragEnd(result: DropResult) {
+    if (!result.destination || result.destination.index === result.source.index) {
+      return;
+    }
+    onSortChange(reorderList(sort, result.source.index, result.destination.index));
+  }
+
+  function handleClearAllButDefault() {
+    const defaultConfig: SortConfig | undefined = sort.find((config) => config.field === defaultOption);
+    onSortChange([defaultConfig ?? { field: defaultOption, direction: 'asc' }]);
+  }
+
+  return (
+    <div
+      className={ cn(
+        'absolute top-full left-0 z-50 mt-1 w-full min-w-60 rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+        className,
+      ) }
+    >
+      <Typography variant="caption0" as="div" className="px-2 py-1.5">
+        { label }
+      </Typography>
+      <Separator className="mb-1" />
+      <DragDropContext onDragEnd={ handleDragEnd }>
+        <Droppable droppableId={ DROPPABLE_ID }>
+          { (droppableProvided) => (
+            <div ref={ droppableProvided.innerRef } { ...droppableProvided.droppableProps }>
+              { sort.map((config, index) => (
+                <Draggable key={ config.field } draggableId={ config.field } index={ index }>
+                  { (draggableProvided, snapshot) => (
+                    <MultiSortMenuItem
+                      option={ config.field }
+                      displayName={ displayMap[config.field] }
+                      checked={ true }
+                      isDefaultOption={ config.field === defaultOption }
+                      direction={ config.direction }
+                      onCheckedChange={ handleCheckedChange }
+                      onDirectionToggle={ handleDirectionToggle }
+                      isDragging={ snapshot.isDragging }
+                      innerRef={ draggableProvided.innerRef }
+                      draggableProps={ draggableProvided.draggableProps }
+                      dragHandleProps={ draggableProvided.dragHandleProps }
+                    />
+                  ) }
+                </Draggable>
+              )) }
+              { droppableProvided.placeholder }
+            </div>
+          ) }
+        </Droppable>
+      </DragDropContext>
+      { uncheckedOptions.map((option) => (
+        <MultiSortMenuItem
+          key={ option }
+          option={ option }
+          displayName={ displayMap[option] }
+          checked={ false }
+          isDefaultOption={ option === defaultOption }
+          onCheckedChange={ handleCheckedChange }
+        />
+      )) }
+      { hasExtraChecked ?
+        <>
+          <Separator className="my-1" />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start gap-2 px-2 text-muted-foreground"
+            onClick={ handleClearAllButDefault }
+          >
+            <ListX className="size-4" />
+            <Typography variant="body0" as="span">
+              Clear all but default
+            </Typography>
+          </Button>
+        </>
+      : null }
+    </div>
+  );
+}

--- a/shared/multi-sort/MultiSortMenuItem.tsx
+++ b/shared/multi-sort/MultiSortMenuItem.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { GripVertical, ArrowUpNarrowWide, ArrowDownNarrowWide } from 'lucide-react';
+import type { DraggableProvidedDraggableProps, DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import Typography from '@/components/typography/Typography';
+import { SortOptions } from '@/store/sorter/table-sort';
+import { SortDirection } from '@/shared/table/table.utils';
+
+interface MultiSortMenuItemProps {
+  option: SortOptions;
+  displayName: string;
+  checked: boolean;
+  /** The default sort option cannot be unchecked. */
+  isDefaultOption: boolean;
+  direction?: SortDirection;
+  onCheckedChange: (option: SortOptions, checked: boolean) => void;
+  onDirectionToggle?: (option: SortOptions) => void;
+  isDragging?: boolean;
+  innerRef?: (element: HTMLElement | null) => void;
+  draggableProps?: DraggableProvidedDraggableProps;
+  dragHandleProps?: DraggableProvidedDragHandleProps | null;
+  className?: string;
+}
+
+export default function MultiSortMenuItem({
+  option,
+  displayName,
+  checked,
+  isDefaultOption,
+  direction,
+  onCheckedChange,
+  onDirectionToggle,
+  isDragging,
+  innerRef,
+  draggableProps,
+  dragHandleProps,
+  className,
+}: MultiSortMenuItemProps) {
+  return (
+    <div
+      ref={ innerRef }
+      { ...draggableProps }
+      className={ cn(
+        'flex w-full items-center gap-2 rounded-sm px-2 py-1.5',
+        isDragging ? 'bg-accent shadow-sm' : 'bg-popover',
+        className,
+      ) }
+    >
+      <Checkbox
+        checked={ checked }
+        disabled={ isDefaultOption }
+        onCheckedChange={ (checkedState) => onCheckedChange(option, checkedState === true) }
+        aria-label={ `Toggle sort by ${displayName}` }
+      />
+      <Typography variant="body1" as="span" className="pointer-events-none min-w-0 flex-1 truncate select-none">
+        { displayName }
+      </Typography>
+      { checked ?
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 px-1.5 text-muted-foreground"
+          onClick={ () => onDirectionToggle?.(option) }
+          aria-label={ `Toggle sort direction for ${displayName}` }
+        >
+          { direction === 'desc' ?
+            <ArrowDownNarrowWide className="size-3.5" />
+          : <ArrowUpNarrowWide className="size-3.5" /> }
+          <Typography variant="caption0" as="span">
+            { direction === 'desc' ? 'desc' : 'asc' }
+          </Typography>
+        </Button>
+      : null }
+      { checked ?
+        <span
+          { ...dragHandleProps }
+          className="
+            flex cursor-grab items-center text-muted-foreground
+            hover:text-foreground
+            active:cursor-grabbing
+          "
+          aria-label={ `Drag to reorder ${displayName}` }
+        >
+          <GripVertical className="size-4" />
+        </span>
+      : null }
+    </div>
+  );
+}

--- a/shared/multi-sort/MultiSortSelect.tsx
+++ b/shared/multi-sort/MultiSortSelect.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useRef, useState, useEffect, useCallback } from 'react';
+
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  SortConfig,
+  SortOptions,
+  DEFAULT_SORT_OPTION,
+  SORT_ORDER_OPTIONS,
+  SortOptionDisplayMap,
+  useCurrentSort,
+  useTableSortActions,
+} from '@/store/sorter/table-sort';
+
+import MultiSortMenu from './MultiSortMenu';
+import useClickOutside from './useClickOutside';
+import MultiSortTriggerChips from './MultiSortTriggerChips';
+
+interface MultiSortSelectProps {
+  /**
+   * If true (default), the zustand store is only updated once the dropdown menu closes.
+   * If false, the store is updated on every check/uncheck/drag/direction change.
+   */
+  fireChangeOnClose?: boolean;
+  /** Max width of the closed combobox display. Longer content truncates with ellipses. */
+  maxWidth?: string;
+  /** Label displayed at the top of the opened dropdown menu. */
+  menuLabel?: string;
+  placeholder?: string;
+  className?: string;
+  menuClassName?: string;
+  options?: SortOptions[];
+  displayMap?: Record<SortOptions, string>;
+  defaultOption?: SortOptions;
+}
+
+export default function MultiSortSelect({
+  fireChangeOnClose = true,
+  maxWidth = '24rem',
+  menuLabel,
+  placeholder,
+  className,
+  menuClassName,
+  options = SORT_ORDER_OPTIONS,
+  displayMap = SortOptionDisplayMap,
+  defaultOption = DEFAULT_SORT_OPTION,
+}: MultiSortSelectProps) {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [isMounted, setIsMounted] = useState<boolean>(false);
+  const [open, setOpen] = useState<boolean>(false);
+  const [draftSort, setDraftSort] = useState<SortConfig[]>([]);
+
+  const currentSort: SortConfig[] = useCurrentSort();
+  const { setCurrentSort } = useTableSortActions();
+
+  // The store is persisted in localstorage, so wait for the client to avoid hydration mismatches.
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setOpen(false);
+    if (fireChangeOnClose) {
+      setCurrentSort(draftSort);
+    }
+  }, [fireChangeOnClose, draftSort, setCurrentSort]);
+
+  useClickOutside(wrapperRef, closeMenu, open);
+
+  function handleToggleOpen() {
+    if (open) {
+      closeMenu();
+    } else {
+      setDraftSort(currentSort);
+      setOpen(true);
+    }
+  }
+
+  function handleSortChange(next: SortConfig[]) {
+    setDraftSort(next);
+    if (!fireChangeOnClose) {
+      setCurrentSort(next);
+    }
+  }
+
+  function handleRemove(option: SortOptions) {
+    if (option === defaultOption) {
+      return;
+    }
+    if (open) {
+      handleSortChange(draftSort.filter((config) => config.field !== option));
+    } else {
+      setCurrentSort(currentSort.filter((config) => config.field !== option));
+    }
+  }
+
+  if (!isMounted) {
+    return <Skeleton className={ cn('h-9 w-full', className) } style={ { maxWidth } } />;
+  }
+
+  const displayedSort: SortConfig[] = open ? draftSort : currentSort;
+
+  return (
+    <div ref={ wrapperRef } className={ cn('relative w-full', className) } style={ { maxWidth } }>
+      <MultiSortTriggerChips
+        sort={ displayedSort }
+        displayMap={ displayMap }
+        defaultOption={ defaultOption }
+        open={ open }
+        onToggleOpen={ handleToggleOpen }
+        onRemove={ handleRemove }
+        placeholder={ placeholder }
+      />
+      { open ?
+        <MultiSortMenu
+          sort={ draftSort }
+          options={ options }
+          displayMap={ displayMap }
+          defaultOption={ defaultOption }
+          onSortChange={ handleSortChange }
+          label={ menuLabel }
+          className={ menuClassName }
+        />
+      : null }
+    </div>
+  );
+}

--- a/shared/multi-sort/MultiSortTriggerChips.tsx
+++ b/shared/multi-sort/MultiSortTriggerChips.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { XIcon, ChevronDownIcon, ArrowUpNarrowWide, ArrowDownNarrowWide } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import Typography from '@/components/typography/Typography';
+import { SortConfig, SortOptions } from '@/store/sorter/table-sort';
+
+interface MultiSortTriggerChipsProps {
+  sort: SortConfig[];
+  displayMap: Record<SortOptions, string>;
+  defaultOption: SortOptions;
+  open: boolean;
+  onToggleOpen: () => void;
+  onRemove: (option: SortOptions) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export default function MultiSortTriggerChips({
+  sort,
+  displayMap,
+  defaultOption,
+  open,
+  onToggleOpen,
+  onRemove,
+  placeholder = 'Sort by...',
+  className,
+}: MultiSortTriggerChipsProps) {
+  return (
+    <div
+      role="combobox"
+      aria-expanded={ open }
+      aria-haspopup="listbox"
+      tabIndex={ 0 }
+      onClick={ onToggleOpen }
+      onKeyDown={ (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onToggleOpen();
+        }
+      } }
+      className={ cn(
+        `
+          flex min-h-9 w-full cursor-pointer flex-nowrap items-center gap-1.5 overflow-hidden rounded-md border border-input
+          bg-transparent px-2.5 py-1.5 text-sm shadow-xs transition-[color,box-shadow]
+          focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50
+          dark:bg-input/30
+        `,
+        className,
+      ) }
+    >
+      { sort.length === 0 ?
+        <Typography variant="subtitle1" as="span" className="truncate">
+          { placeholder }
+        </Typography>
+      : <div className="flex min-w-0 flex-1 flex-nowrap items-center gap-1.5 overflow-hidden">
+          { sort.map((config) => (
+            <span
+              key={ config.field }
+              data-slot="multi-sort-chip"
+              className="flex h-[calc(--spacing(5.5))] min-w-0 shrink items-center gap-1 rounded-sm bg-muted px-1.5"
+            >
+              <Typography variant="caption0" as="span" className="truncate text-foreground">
+                { displayMap[config.field] }
+              </Typography>
+              { config.direction === 'desc' ?
+                <ArrowDownNarrowWide className="size-3 shrink-0 text-muted-foreground" />
+              : <ArrowUpNarrowWide className="size-3 shrink-0 text-muted-foreground" /> }
+              { config.field === defaultOption ? null : (
+                <button
+                  type="button"
+                  aria-label={ `Remove ${displayMap[config.field]} sort` }
+                  className="
+                    shrink-0 rounded-xs opacity-50
+                    hover:opacity-100
+                  "
+                  onClick={ (event) => {
+                    event.stopPropagation();
+                    onRemove(config.field);
+                  } }
+                >
+                  <XIcon className="size-3" />
+                </button>
+              ) }
+            </span>
+          )) }
+        </div>
+      }
+      <ChevronDownIcon className="ml-auto size-4 shrink-0 text-muted-foreground" />
+    </div>
+  );
+}

--- a/shared/multi-sort/multi-sort.query.ts
+++ b/shared/multi-sort/multi-sort.query.ts
@@ -1,0 +1,34 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { SortConfig } from '@/store/sorter/table-sort';
+
+export interface FakeSortedSearchResponse {
+  /** The fake GET request URL that was "called". */
+  requestUrl: string;
+  /** The sort configs that produced the request. */
+  sortConfig: SortConfig[];
+  fetchedAt: string;
+}
+
+// Fetch functions
+async function getFakeSortedSearch(sortConfig: SortConfig[], searchParamsString: string): Promise<FakeSortedSearchResponse> {
+  const requestUrl = `search?${searchParamsString}`;
+
+  // Fake (example) GET request. In a real app this would be something like:
+  // const response = await fetch(`/api/${requestUrl}`, { signal });
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  return {
+    requestUrl,
+    sortConfig,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+// TanStack Query options
+export function getFakeSortedSearchQueryOptions(sortConfig: SortConfig[], searchParamsString: string) {
+  return queryOptions({
+    queryKey: ['fake-sorted-search', searchParamsString],
+    queryFn: async () => await getFakeSortedSearch(sortConfig, searchParamsString),
+  });
+}

--- a/shared/multi-sort/multi-sort.utils.ts
+++ b/shared/multi-sort/multi-sort.utils.ts
@@ -1,0 +1,38 @@
+import { SortConfig, SortOptions } from '@/store/sorter/table-sort';
+
+/**
+ * Converts a sort config array to a URLSearchParams string.
+ * All `sort` keys come first (in order), then all `direction` keys (in the same order).
+ * Example: sort=arrival_date&sort=user_id&direction=asc&direction=desc
+ */
+export function buildSortSearchParamsString(sort: SortConfig[]): string {
+  const params = new URLSearchParams();
+
+  for (const config of sort) {
+    params.append('sort', config.field);
+  }
+  for (const config of sort) {
+    params.append('direction', config.direction);
+  }
+
+  return params.toString();
+}
+
+/**
+ * Returns the options that are not part of the checked sort configs, preserving
+ * the order they appear in `allOptions`.
+ */
+export function getUncheckedOptions(checked: SortConfig[], allOptions: SortOptions[]): SortOptions[] {
+  const checkedFields = new Set<SortOptions>(checked.map((config) => config.field));
+  return allOptions.filter((option) => !checkedFields.has(option));
+}
+
+/**
+ * Immutably moves an item within a list from one index to another.
+ */
+export function reorderList<T>(list: T[], startIndex: number, endIndex: number): T[] {
+  const result = [...list];
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+  return result;
+}

--- a/shared/multi-sort/useClickOutside.ts
+++ b/shared/multi-sort/useClickOutside.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Calls `handler` when a pointer down event happens outside of the given element.
+ * Only active while `enabled` is true.
+ */
+export default function useClickOutside(ref: RefObject<HTMLElement | null>, handler: () => void, enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    function handlePointerDown(event: MouseEvent | TouchEvent) {
+      const element = ref.current;
+      if (!element) {
+        return;
+      }
+      if (event.target instanceof Node && !element.contains(event.target)) {
+        handler();
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+    };
+  }, [ref, handler, enabled]);
+}

--- a/shared/multi-sort/useMultiSortValues.ts
+++ b/shared/multi-sort/useMultiSortValues.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { SortConfig, useCurrentSort } from '@/store/sorter/table-sort';
+
+import { buildSortSearchParamsString } from './multi-sort.utils';
+
+interface MultiSortValues {
+  /** The raw sort configs, in the order the user arranged them. */
+  sortConfig: SortConfig[];
+  /** URLSearchParams string, e.g. sort=arrival_date&sort=user_id&direction=asc&direction=desc */
+  searchParamsString: string;
+}
+
+export default function useMultiSortValues(): MultiSortValues {
+  const currentSort = useCurrentSort();
+
+  const searchParamsString = useMemo(() => {
+    return buildSortSearchParamsString(currentSort);
+  }, [currentSort]);
+
+  return {
+    sortConfig: currentSort,
+    searchParamsString,
+  };
+}

--- a/store/sorter/table-sort.ts
+++ b/store/sorter/table-sort.ts
@@ -22,6 +22,29 @@ export const DEFAULT_SORT_OPTION: SortOptions = 'arrival_date'; // this item sho
 
 export const DEFAULT_SORT_ARRAY: SortConfig[] = [{ field: DEFAULT_SORT_OPTION, direction: 'asc' }];
 
+/**
+ * Normalizes a sort array at the store boundary: drops entries whose field is not a known
+ * sort option, dedupes by field (first occurrence wins), coerces directions to asc/desc,
+ * and guarantees DEFAULT_SORT_OPTION is always present. Caller-provided order is preserved.
+ */
+export function normalizeSortConfigs(sort: SortConfig[]): SortConfig[] {
+  const seenFields = new Set<SortOptions>();
+  const validSort: SortConfig[] = [];
+
+  for (const config of sort) {
+    if (!config || !SORT_ORDER_OPTIONS.includes(config.field) || seenFields.has(config.field)) {
+      continue;
+    }
+    seenFields.add(config.field);
+    validSort.push({ field: config.field, direction: config.direction === 'desc' ? 'desc' : 'asc' });
+  }
+
+  if (!seenFields.has(DEFAULT_SORT_OPTION)) {
+    return [...DEFAULT_SORT_ARRAY, ...validSort];
+  }
+  return validSort;
+}
+
 type TableSortState = {
   currentSort: SortConfig[];
 
@@ -38,7 +61,7 @@ const tableSortStoreBase = create<TableSortState>()(
 
       actions: {
         setCurrentSort: (sort: SortConfig[]) => {
-          set(() => ({ currentSort: sort }));
+          set(() => ({ currentSort: normalizeSortConfigs(sort) }));
         },
         clearCurrentSort: () => {
           set(() => ({ currentSort: DEFAULT_SORT_ARRAY }));
@@ -51,6 +74,14 @@ const tableSortStoreBase = create<TableSortState>()(
       partialize: (state) => ({
         currentSort: state.currentSort,
       }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<Pick<TableSortState, 'currentSort'>> | undefined;
+        const persistedSort = Array.isArray(persisted?.currentSort) ? persisted.currentSort : currentState.currentSort;
+        return {
+          ...currentState,
+          currentSort: normalizeSortConfigs(persistedSort),
+        };
+      },
     },
   ),
 );

--- a/store/sorter/table-sort.ts
+++ b/store/sorter/table-sort.ts
@@ -1,25 +1,26 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { SortDirection } from '@/shared/table/table.utils';
 
-type SortOptions = 'arrival_date' | 'status' | 'user_id';
+export type SortOptions = 'arrival_date' | 'status' | 'user_id';
 
-interface SortConfig {
+export interface SortConfig {
   field: SortOptions;
   direction: SortDirection;
 }
 
-const SORT_ORDER_OPTIONS = ['arrival_date', 'status', 'user_id'];
+export const SORT_ORDER_OPTIONS: SortOptions[] = ['arrival_date', 'status', 'user_id'];
 
-const SortOptionDisplayMap = {
+export const SortOptionDisplayMap: Record<SortOptions, string> = {
   arrival_date: 'Arrival Date',
   status: 'Status',
   user_id: 'User ID',
 };
 
-const DEFAULT_SORT_OPTION = 'arrival_date'; // this item should always be checked and not removable
+export const DEFAULT_SORT_OPTION: SortOptions = 'arrival_date'; // this item should always be checked and not removable
 
-const DEFAULT_SORT_ARRAY: SortConfig[] = [{ field: DEFAULT_SORT_OPTION, direction: 'asc' }];
+export const DEFAULT_SORT_ARRAY: SortConfig[] = [{ field: DEFAULT_SORT_OPTION, direction: 'asc' }];
 
 type TableSortState = {
   currentSort: SortConfig[];
@@ -30,18 +31,29 @@ type TableSortState = {
   };
 };
 
-const tableSortStoreBase = create<TableSortState>()((set) => ({
-  currentSort: DEFAULT_SORT_ARRAY,
+const tableSortStoreBase = create<TableSortState>()(
+  persist(
+    (set) => ({
+      currentSort: DEFAULT_SORT_ARRAY,
 
-  actions: {
-    setCurrentSort: (sort: SortConfig[]) => {
-      set(() => ({ currentSort: sort }));
+      actions: {
+        setCurrentSort: (sort: SortConfig[]) => {
+          set(() => ({ currentSort: sort }));
+        },
+        clearCurrentSort: () => {
+          set(() => ({ currentSort: DEFAULT_SORT_ARRAY }));
+        },
+      },
+    }),
+    {
+      name: 'table-sort-store',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        currentSort: state.currentSort,
+      }),
     },
-    clearCurrentSort: () => {
-      set(() => ({ currentSort: DEFAULT_SORT_ARRAY }));
-    },
-  },
-}));
+  ),
+);
 
 export const useCurrentSort = () => tableSortStoreBase((state) => state.currentSort);
 export const useTableSortActions = () => tableSortStoreBase((state) => state.actions);

--- a/store/sorter/table-sort.ts
+++ b/store/sorter/table-sort.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+
+import { SortDirection } from '@/shared/table/table.utils';
+
+type SortOptions = 'arrival_date' | 'status' | 'user_id';
+
+interface SortConfig {
+  field: SortOptions;
+  direction: SortDirection;
+}
+
+const SORT_ORDER_OPTIONS = ['arrival_date', 'status', 'user_id'];
+
+const SortOptionDisplayMap = {
+  arrival_date: 'Arrival Date',
+  status: 'Status',
+  user_id: 'User ID',
+};
+
+const DEFAULT_SORT_OPTION = 'arrival_date'; // this item should always be checked and not removable
+
+const DEFAULT_SORT_ARRAY: SortConfig[] = [{ field: DEFAULT_SORT_OPTION, direction: 'asc' }];
+
+type TableSortState = {
+  currentSort: SortConfig[];
+
+  actions: {
+    setCurrentSort: (sort: SortConfig[]) => void;
+    clearCurrentSort: () => void;
+  };
+};
+
+const tableSortStoreBase = create<TableSortState>()((set) => ({
+  currentSort: DEFAULT_SORT_ARRAY,
+
+  actions: {
+    setCurrentSort: (sort: SortConfig[]) => {
+      set(() => ({ currentSort: sort }));
+    },
+    clearCurrentSort: () => {
+      set(() => ({ currentSort: DEFAULT_SORT_ARRAY }));
+    },
+  },
+}));
+
+export const useCurrentSort = () => tableSortStoreBase((state) => state.currentSort);
+export const useTableSortActions = () => tableSortStoreBase((state) => state.actions);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a reusable multi-sort select with chips, checkbox menu, and drag-to-reorder, backed by a persisted `zustand` store and a hook that returns both the sort array and a URLSearchParams string. Also updates `Typography` to honor `as`, default non-intrinsic variants to `<p>`, and add `p0`/`p1`/`p2` and `span0`/`span1`/`span2`.

- **New Features**
  - `MultiSortSelect`: chips trigger, checkbox menu, per-item asc/desc toggle, and drag-to-reorder for checked items via `@hello-pangea/dnd`; includes “clear all but default”; `fireChangeOnClose` (default true) defers store updates until the menu closes.
  - `store/sorter/table-sort`: persists `currentSort` with normalization (drops unknown fields, dedupes, coerces directions, re-adds default if missing).
  - `useMultiSortValues`: returns `SortConfig[]` and the `URLSearchParams` string; demo wired into `/app/(base)/test` with a fake GET using `@tanstack/react-query`.

- **Bug Fixes**
  - `Typography`: `as` prop respected for all variants; defaults updated so `h1`–`h5`/`p` render intrinsically, `h6` and `span0/1/2` render as `<span>`, and all other variants default to `<p>`; adds ref support.

<sup>Written for commit 0888c685d1222e26cfc692fc6d2cd79904882de8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yiqu/tb/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

