### PR TITLE
Table auto resizer

### DIFF
--- a/app/(base)/bills/_components/BillsTableParentContent.tsx
+++ b/app/(base)/bills/_components/BillsTableParentContent.tsx
@@ -93,7 +93,6 @@ export default function BillsTableParentContent({ billDues, tableId, sortData, p
                               sortData={ sortData }
                               pageId={ pageId }
                               sortable={ unsortableBillsColumns[column] ?? true }
-                              hideRightBorder={ index === columnsSorted.length - 1 }
                               onSortUpdate={ handleOnSortUpdate }
                             />
                           );

--- a/app/(base)/bills/_components/BillsTableParentContent.tsx
+++ b/app/(base)/bills/_components/BillsTableParentContent.tsx
@@ -93,6 +93,7 @@ export default function BillsTableParentContent({ billDues, tableId, sortData, p
                               sortData={ sortData }
                               pageId={ pageId }
                               sortable={ unsortableBillsColumns[column] ?? true }
+                              hideRightBorder={ index === columnsSorted.length - 1 }
                               onSortUpdate={ handleOnSortUpdate }
                             />
                           );

--- a/app/(base)/bills/_components/BillsTableParentContent.tsx
+++ b/app/(base)/bills/_components/BillsTableParentContent.tsx
@@ -7,6 +7,7 @@ import useIsClient from '@/hooks/useIsClient';
 import BillsTableLoading from '@/shared/loading/BillsTableLoading';
 import { upsertSortData2 } from '@/server/sort-data/sort-data.server';
 import FormattedTableHeader from '@/shared/table/FormattedTableHeader';
+import FormattedTableHeadFiller from '@/shared/table/FormattedTableHeadFiller';
 import { Table, TableRow, TableBody, TableHeader } from '@/components/ui/table';
 import { SortDataModel, SortDataPageId, SortDataUpsertable } from '@/models/sort-data/SortData.model';
 import { BillDueWithSubscription, BillDueWithSubscriptionAndSortData } from '@/models/bills/bills.model';
@@ -76,7 +77,7 @@ export default function BillsTableParentContent({ billDues, tableId, sortData, p
             { (droppableProvided) => {
               return (
                 <TableRow ref={ droppableProvided.innerRef } { ...droppableProvided.droppableProps } className="hover:bg-transparent">
-                  { columnsSorted.map((column: string, index: number, array: string[]) => {
+                  { columnsSorted.map((column: string, index: number) => {
                     return (
                       <Draggable key={ column } draggableId={ column } index={ index }>
                         { (draggableProvided, snapshot) => {
@@ -89,7 +90,6 @@ export default function BillsTableParentContent({ billDues, tableId, sortData, p
                               isDragging={ snapshot.isDragging }
                               columnId={ column }
                               index={ index }
-                              length={ array.length }
                               sortData={ sortData }
                               pageId={ pageId }
                               sortable={ unsortableBillsColumns[column] ?? true }
@@ -102,6 +102,7 @@ export default function BillsTableParentContent({ billDues, tableId, sortData, p
                   }) }
 
                   { droppableProvided.placeholder }
+                  <FormattedTableHeadFiller />
                 </TableRow>
               );
             } }

--- a/app/(base)/bills/_components/BillsTableParentRow.tsx
+++ b/app/(base)/bills/_components/BillsTableParentRow.tsx
@@ -22,7 +22,7 @@ export default function BillsTableParentRow({ billDue }: { billDue: BillDueWithS
           billDue={ billDue }
           showHoverFilter
           isSticky={ index === 0 }
-          showVerticalBorder={ index !== columnsSorted.length - 1 }
+          showVerticalBorder
         />
       )) }
     </BillsTableParentRowWrapper>

--- a/app/(base)/bills/_components/BillsTableParentRow.tsx
+++ b/app/(base)/bills/_components/BillsTableParentRow.tsx
@@ -22,7 +22,7 @@ export default function BillsTableParentRow({ billDue }: { billDue: BillDueWithS
           billDue={ billDue }
           showHoverFilter
           isSticky={ index === 0 }
-          showVerticalBorder
+          showVerticalBorder={ index !== columnsSorted.length - 1 }
         />
       )) }
     </BillsTableParentRowWrapper>

--- a/app/(base)/bills/_components/BillsTableParentRowWrapper.tsx
+++ b/app/(base)/bills/_components/BillsTableParentRowWrapper.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@/lib/utils';
 import { TableRow } from '@/components/ui/table';
 import { BillDueWithSubscription } from '@/models/bills/bills.model';
+import FormattedTableCellFiller from '@/shared/table/FormattedTableCellFiller';
 import { BillDueIdBeingEdited, useGetBillDueIdBeingEdited } from '@/store/bills/bills.store';
 
 export default function BillsTableParentRowWrapper({ billDue, children }: { billDue: BillDueWithSubscription; children: React.ReactNode }) {
@@ -15,6 +16,7 @@ export default function BillsTableParentRowWrapper({ billDue, children }: { bill
       }) }
     >
       { children }
+      <FormattedTableCellFiller />
     </TableRow>
   );
 }

--- a/app/(base)/search/_components/SearchTableParent.tsx
+++ b/app/(base)/search/_components/SearchTableParent.tsx
@@ -33,6 +33,7 @@ export default async function SearchTableParent() {
                     index={ index }
                     sortData={ billDues.sortData }
                     pageId={ SORT_DATA_PAGE_IDS.search }
+                    hideRightBorder={ index === columnsSorted.length - 1 }
                   />
                 );
               }) }

--- a/app/(base)/search/_components/SearchTableParent.tsx
+++ b/app/(base)/search/_components/SearchTableParent.tsx
@@ -33,7 +33,6 @@ export default async function SearchTableParent() {
                     index={ index }
                     sortData={ billDues.sortData }
                     pageId={ SORT_DATA_PAGE_IDS.search }
-                    hideRightBorder={ index === columnsSorted.length - 1 }
                   />
                 );
               }) }

--- a/app/(base)/search/_components/SearchTableParent.tsx
+++ b/app/(base)/search/_components/SearchTableParent.tsx
@@ -7,6 +7,8 @@ import { SortDataModel } from '@/models/sort-data/SortData.model';
 import SearchTableCell from '@/shared/table/SearchTableCellDisplay';
 import FormattedTableHeader from '@/shared/table/FormattedTableHeader';
 import { BILLS_TABLE_COLUMNS } from '@/store/subscriptions/table.store';
+import FormattedTableHeadFiller from '@/shared/table/FormattedTableHeadFiller';
+import FormattedTableCellFiller from '@/shared/table/FormattedTableCellFiller';
 import { Table, TableRow, TableBody, TableHeader } from '@/components/ui/table';
 import { getSortDataForPageIdCached } from '@/server/sort-data/sort-data.server';
 import { BillDueWithSubscription, BillDueWithSubscriptionAndSortData } from '@/models/bills/bills.model';
@@ -22,19 +24,19 @@ export default async function SearchTableParent() {
         <Table className={ `table-fixed` }>
           <TableHeader className="bg-muted">
             <TableRow className="hover:bg-transparent">
-              { columnsSorted.map((column: string, index: number, array: string[]) => {
+              { columnsSorted.map((column: string, index: number) => {
                 return (
                   <FormattedTableHeader
                     tableId="search"
                     key={ column }
                     columnId={ column }
                     index={ index }
-                    length={ array.length }
                     sortData={ billDues.sortData }
                     pageId={ SORT_DATA_PAGE_IDS.search }
                   />
                 );
               }) }
+              <FormattedTableHeadFiller />
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -43,6 +45,7 @@ export default async function SearchTableParent() {
                 { BILLS_TABLE_COLUMNS.map((column: string) => (
                   <SearchTableCell key={ column } colId={ column } billDue={ billDue } />
                 )) }
+                <FormattedTableCellFiller />
               </TableRow>
             )) }
           </TableBody>

--- a/app/(base)/subscriptions/[subscriptionId]/_components/SubscriptionDetailsBillsTable.tsx
+++ b/app/(base)/subscriptions/[subscriptionId]/_components/SubscriptionDetailsBillsTable.tsx
@@ -6,6 +6,7 @@ import { SORT_DATA_PAGE_IDS } from '@/constants/constants';
 import { BillDueWithSubscription } from '@/models/bills/bills.model';
 import { upsertSortData2 } from '@/server/sort-data/sort-data.server';
 import FormattedTableHeader from '@/shared/table/FormattedTableHeader';
+import FormattedTableHeadFiller from '@/shared/table/FormattedTableHeadFiller';
 import { SortDataUpsertable } from '@/models/sort-data/SortData.model';
 import { BILLS_TABLE_COLUMNS } from '@/store/subscriptions/table.store';
 import BillsTableParentRow from '@/shared/table/BillsDueTableParentRow';
@@ -28,20 +29,20 @@ export default function SubscriptionDetailsBillsTable({ billDues }: Subscription
         <Table className="table-fixed">
           <TableHeader className={ `bg-muted` }>
             <TableRow className="hover:bg-transparent">
-              { columnsSorted.map((column: string, index: number, array: string[]) => {
+              { columnsSorted.map((column: string, index: number) => {
                 return (
                   <FormattedTableHeader
                     tableId="bills"
                     key={ column }
                     columnId={ column }
                     index={ index }
-                    length={ array.length }
                     sortData={ null }
                     pageId={ SORT_DATA_PAGE_IDS.subscriptionDetailsBillsBillsTable }
                     onSortUpdate={ handleOnSortUpdate }
                   />
                 );
               }) }
+              <FormattedTableHeadFiller />
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/app/(base)/subscriptions/[subscriptionId]/_components/SubscriptionDetailsBillsTable.tsx
+++ b/app/(base)/subscriptions/[subscriptionId]/_components/SubscriptionDetailsBillsTable.tsx
@@ -38,7 +38,6 @@ export default function SubscriptionDetailsBillsTable({ billDues }: Subscription
                     index={ index }
                     sortData={ null }
                     pageId={ SORT_DATA_PAGE_IDS.subscriptionDetailsBillsBillsTable }
-                    hideRightBorder={ index === columnsSorted.length - 1 }
                     onSortUpdate={ handleOnSortUpdate }
                   />
                 );

--- a/app/(base)/subscriptions/[subscriptionId]/_components/SubscriptionDetailsBillsTable.tsx
+++ b/app/(base)/subscriptions/[subscriptionId]/_components/SubscriptionDetailsBillsTable.tsx
@@ -38,6 +38,7 @@ export default function SubscriptionDetailsBillsTable({ billDues }: Subscription
                     index={ index }
                     sortData={ null }
                     pageId={ SORT_DATA_PAGE_IDS.subscriptionDetailsBillsBillsTable }
+                    hideRightBorder={ index === columnsSorted.length - 1 }
                     onSortUpdate={ handleOnSortUpdate }
                   />
                 );

--- a/app/(base)/subscriptions/_components/SubscriptionsTableParentRow.tsx
+++ b/app/(base)/subscriptions/_components/SubscriptionsTableParentRow.tsx
@@ -20,7 +20,7 @@ export default function SubscriptionsTableParentRow({ subscription }: { subscrip
           key={ column }
           colId={ column }
           subscription={ subscription }
-          showVerticalBorder={ index !== columnsSorted.length - 1 }
+          showVerticalBorder
           isSticky={ index === 0 }
         />
       )) }

--- a/app/(base)/subscriptions/_components/SubscriptionsTableParentRow.tsx
+++ b/app/(base)/subscriptions/_components/SubscriptionsTableParentRow.tsx
@@ -20,7 +20,7 @@ export default function SubscriptionsTableParentRow({ subscription }: { subscrip
           key={ column }
           colId={ column }
           subscription={ subscription }
-          showVerticalBorder
+          showVerticalBorder={ index !== columnsSorted.length - 1 }
           isSticky={ index === 0 }
         />
       )) }

--- a/app/(base)/subscriptions/_components/SubscriptionsTableParentRowWrapper.tsx
+++ b/app/(base)/subscriptions/_components/SubscriptionsTableParentRowWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/lib/utils';
 import { TableRow } from '@/components/ui/table';
+import FormattedTableCellFiller from '@/shared/table/FormattedTableCellFiller';
 import { SubscriptionWithBillDues } from '@/models/subscriptions/subscriptions.model';
 import { SubscriptionIdBeingEdited, useGetSubscriptionBeingEdited } from '@/store/subscriptions/subscriptions.store';
 
@@ -21,6 +22,7 @@ export default function SubscriptionsTableParentRowWrapper({
       }) }
     >
       { children }
+      <FormattedTableCellFiller />
     </TableRow>
   );
 }

--- a/app/(base)/subscriptions/_components/SubscriptionsTableParentWrapper.tsx
+++ b/app/(base)/subscriptions/_components/SubscriptionsTableParentWrapper.tsx
@@ -86,6 +86,7 @@ export default function SubscriptionsTableParentWrapper({ subscriptions }: Props
                         sortData={ subscriptions.sortData }
                         pageId={ SORT_DATA_PAGE_IDS.subscriptions }
                         sortable={ unsortableSubscriptionsColumns[column] ?? true }
+                        hideRightBorder={ index === columnsSorted.length - 1 }
                         onSortUpdate={ handleOnSortUpdate }
                       />
                     ) }

--- a/app/(base)/subscriptions/_components/SubscriptionsTableParentWrapper.tsx
+++ b/app/(base)/subscriptions/_components/SubscriptionsTableParentWrapper.tsx
@@ -8,6 +8,7 @@ import { SORT_DATA_PAGE_IDS } from '@/constants/constants';
 import BillsTableLoading from '@/shared/loading/BillsTableLoading';
 import { upsertSortData2 } from '@/server/sort-data/sort-data.server';
 import FormattedTableHeader from '@/shared/table/FormattedTableHeader';
+import FormattedTableHeadFiller from '@/shared/table/FormattedTableHeadFiller';
 import { SortDataUpsertable } from '@/models/sort-data/SortData.model';
 import { Table, TableRow, TableBody, TableHeader } from '@/components/ui/table';
 import { SubscriptionWithBillDues, SubscriptionWithBillDuesAndSortData } from '@/models/subscriptions/subscriptions.model';
@@ -71,7 +72,7 @@ export default function SubscriptionsTableParentWrapper({ subscriptions }: Props
           <Droppable droppableId="table-columns" direction="horizontal">
             { (droppableProvided) => (
               <TableRow ref={ droppableProvided.innerRef } { ...droppableProvided.droppableProps } className="hover:bg-transparent">
-                { columnsSorted.map((column: string, index: number, array: string[]) => (
+                { columnsSorted.map((column: string, index: number) => (
                   <Draggable key={ column } draggableId={ column } index={ index }>
                     { (draggableProvided, snapshot) => (
                       <FormattedTableHeader
@@ -82,7 +83,6 @@ export default function SubscriptionsTableParentWrapper({ subscriptions }: Props
                         isDragging={ snapshot.isDragging }
                         columnId={ column }
                         index={ index }
-                        length={ array.length }
                         sortData={ subscriptions.sortData }
                         pageId={ SORT_DATA_PAGE_IDS.subscriptions }
                         sortable={ unsortableSubscriptionsColumns[column] ?? true }
@@ -92,6 +92,7 @@ export default function SubscriptionsTableParentWrapper({ subscriptions }: Props
                   </Draggable>
                 )) }
                 { droppableProvided.placeholder }
+                <FormattedTableHeadFiller />
               </TableRow>
             ) }
           </Droppable>

--- a/app/(base)/subscriptions/_components/SubscriptionsTableParentWrapper.tsx
+++ b/app/(base)/subscriptions/_components/SubscriptionsTableParentWrapper.tsx
@@ -86,7 +86,6 @@ export default function SubscriptionsTableParentWrapper({ subscriptions }: Props
                         sortData={ subscriptions.sortData }
                         pageId={ SORT_DATA_PAGE_IDS.subscriptions }
                         sortable={ unsortableSubscriptionsColumns[column] ?? true }
-                        hideRightBorder={ index === columnsSorted.length - 1 }
                         onSortUpdate={ handleOnSortUpdate }
                       />
                     ) }

--- a/hooks/useColumnResize.ts
+++ b/hooks/useColumnResize.ts
@@ -2,6 +2,8 @@
 
 import { useRef, useState, useCallback } from 'react';
 
+import useAutoColumnWidth from '@/shared/table-auto-width/useAutoColumnWidth';
+
 interface UseColumnResizeOptions {
   /** Identifier for the column being resized, forwarded to onWidthChange. */
   columnId: string;
@@ -29,10 +31,15 @@ interface UseColumnResizeOptions {
  *    listeners are removed, and a one-shot capture-phase click handler swallows the
  *    subsequent click event to prevent it from triggering column sort.
  *
+ * Double clicking the handle auto-fits the column to its currently rendered
+ * content (via the composable `useAutoColumnWidth` hook in `/shared/table-auto-width`)
+ * and commits the measured width through the same `onWidthChange` callback.
+ *
  * @returns
  * - `currentWidth`  – the width to apply to the column (live during drag, `initialWidth` otherwise).
  * - `isResizing`    – `true` while a drag is in progress; useful for styling.
  * - `handleResizePointerDown` – attach to the resize handle's `onPointerDown`.
+ * - `handleResizeDoubleClick` – attach to the resize handle's `onDoubleClick` to auto-fit the column.
  */
 export default function useColumnResize({ columnId, initialWidth, minWidth = 100, maxWidth = 400, onWidthChange }: UseColumnResizeOptions) {
   // Tracks the live width during a drag; null when idle so we fall back to initialWidth.
@@ -40,6 +47,9 @@ export default function useColumnResize({ columnId, initialWidth, minWidth = 100
   const [isResizing, setIsResizing] = useState(false);
   // Ref instead of state so move/up handlers always read the latest values without re-renders.
   const dragState = useRef({ startX: 0, startWidth: 0 });
+
+  // Double clicking the resize handle auto-fits the column to its rendered content.
+  const { handleAutoFitDoubleClick } = useAutoColumnWidth({ columnId, minWidth, maxWidth, onWidthChange });
 
   /** Document-level pointermove: updates the live column width as the user drags. */
   const handlePointerMove = useCallback(
@@ -104,5 +114,7 @@ export default function useColumnResize({ columnId, initialWidth, minWidth = 100
     isResizing,
     /** Pointer-down handler to attach to the resize handle element. */
     handleResizePointerDown,
+    /** Double-click handler to attach to the resize handle element — auto-fits the column to its content. */
+    handleResizeDoubleClick: handleAutoFitDoubleClick,
   };
 }

--- a/plans/table-auto-width/plan.md
+++ b/plans/table-auto-width/plan.md
@@ -1,0 +1,27 @@
+# Objective
+
+- Be able to auto adjust table's column width by double clicking the resizer component <FormattedTableHeadResizeHandle />.
+
+# Specs
+
+- In FormattedTableHeader component, which is a shared component that is used by many different datasets. There is FormattedTableHeadResizeHandle. 
+- User should be able to double click FormattedTableHeadResizeHandle, and it will auto resize the column based on the content of the visible content of the table.
+- For example, BillsTableParentContent wraps FormattedTableHeader and the drag handler action takes place in BillsTableParentContent.
+- I need this feature to work on any dataset though, newly added code or components should be easily shared across the app, and copy paste-able to other projects.
+- Make use of libraries if needs to, like zustand or whatnot if needs to.
+- The solution should be flexible, not tied down to a specific set of data or hardcoded stuff, it needs to be composable. Preferably the logic will live in useColumnResize.ts hook.
+- After double clicking, which resizes, it should still save that to the zustand table state like how we currently do with the hook useColumnResize.ts.
+
+
+# Test
+
+- Make BillsTableParentContent work with this new feature.
+- One thing to note: a table could be infinite scrolling, so just auto size to what's currently on screen or loaded. Data will be loaded with tanstack infinite query if that matters. In this app, everything is paged though, but could be infinite scrolling in the future.
+
+
+# Details
+
+- all displays should be in its file.
+- all work should be componentized, with props if needed.
+- this component should be in its own sub folder in /shared. So it is easily portable.
+- use hooks and create hooks as needed (prefer custom hooks the most)

--- a/shared/table-auto-width/README.md
+++ b/shared/table-auto-width/README.md
@@ -1,0 +1,31 @@
+# table-auto-width
+
+Auto-fit a table column's width to its rendered content by double clicking the column's resize handle.
+
+Self-contained and portable: only React + standard DOM APIs — no dataset, store, or UI-library coupling. Copy this folder into any project that renders a native `<table>`.
+
+## Files
+
+- `useAutoColumnWidth.ts` — hook returning `handleAutoFitDoubleClick`, an `onDoubleClick` handler for any element inside a column's `<th>` (typically the resize handle). Persisting the result is delegated to the `onWidthChange` callback.
+- `tableAutoWidth.utils.ts` — pure DOM measurement. Clones the column's rendered cells into a hidden off-screen single-column table (`table-layout: auto`, `white-space: nowrap` forced) and reads the widest cell's intrinsic width.
+
+## Usage
+
+```tsx
+const { handleAutoFitDoubleClick } = useAutoColumnWidth({
+  columnId,
+  minWidth: 80,
+  maxWidth: 1200,
+  onWidthChange: setColumnWidth, // e.g. persist to a zustand table store
+});
+
+<div onPointerDown={ handleResizePointerDown } onDoubleClick={ handleAutoFitDoubleClick } />;
+```
+
+In this app it is composed by `hooks/useColumnResize.ts` (returned as `handleResizeDoubleClick`) and wired to `FormattedTableHeadResizeHandle`.
+
+## Notes
+
+- Only cells currently in the DOM are measured — paged and infinite-scroll (e.g. TanStack infinite query) tables auto-fit to what is loaded.
+- `maxRowsToMeasure` caps measurement work on very large tables.
+- Header content is included by default (`includeHeader`).

--- a/shared/table-auto-width/tableAutoWidth.utils.ts
+++ b/shared/table-auto-width/tableAutoWidth.utils.ts
@@ -1,0 +1,168 @@
+/**
+ * DOM measurement utilities for auto-sizing a table column to fit its content.
+ *
+ * Portable by design: these helpers only rely on standard DOM APIs and the
+ * native `<table>` structure (`th.cellIndex` + `row.cells[index]`), so they are
+ * not tied to any specific dataset, store, or component library. Copy this
+ * folder into another project and it will work with any `<table>`-based grid.
+ *
+ * How the measurement works:
+ * 1. Starting from the column's header cell (`<th>`), find the owning `<table>`
+ *    and collect every currently rendered body cell in the same column position.
+ *    Only cells present in the DOM are measured — for paged or infinite-scroll
+ *    tables this naturally means "what is currently loaded".
+ * 2. Clone each cell into an off-screen, single-column measurement table with
+ *    `table-layout: auto` and `white-space: nowrap` forced on, so every clone
+ *    renders at its intrinsic (un-truncated, un-wrapped) content width.
+ * 3. The measurement table's rendered width is the widest cell's content width
+ *    (padding included, since the cells themselves are cloned).
+ * 4. Clean up the off-screen container and return the clamped result.
+ */
+
+export interface MeasureColumnAutoWidthOptions {
+  /** Minimum allowed width in px. @default 80 */
+  minWidth?: number;
+  /** Maximum allowed width in px. @default 1200 */
+  maxWidth?: number;
+  /** Extra px added on top of the measured content width for breathing room. @default 16 */
+  extraPadding?: number;
+  /** Whether the header cell's own content participates in the measurement. @default true */
+  includeHeader?: boolean;
+  /** Safety cap on how many body rows are measured, for very large tables. @default 200 */
+  maxRowsToMeasure?: number;
+}
+
+const DEFAULT_MIN_WIDTH = 80;
+const DEFAULT_MAX_WIDTH = 1200;
+const DEFAULT_EXTRA_PADDING = 16;
+const DEFAULT_MAX_ROWS_TO_MEASURE = 200;
+
+/** Collects the header cell (optionally) and every rendered body cell occupying the same column position. */
+function collectColumnCells(headerCell: HTMLTableCellElement, includeHeader: boolean, maxRowsToMeasure: number): HTMLTableCellElement[] {
+  const table: HTMLTableElement | null = headerCell.closest('table');
+
+  if (!table) {
+    return [];
+  }
+
+  const columnIndex = headerCell.cellIndex;
+  const cells: HTMLTableCellElement[] = [];
+
+  if (includeHeader) {
+    cells.push(headerCell);
+  }
+
+  let measuredRows = 0;
+  for (const tBody of table.tBodies) {
+    for (const row of tBody.rows) {
+      if (measuredRows >= maxRowsToMeasure) {
+        return cells;
+      }
+
+      const cell: HTMLTableCellElement | undefined = row.cells[columnIndex];
+      if (cell) {
+        cells.push(cell);
+        measuredRows++;
+      }
+    }
+  }
+
+  return cells;
+}
+
+/**
+ * Builds a hidden, off-screen single-column table used to render cell clones at
+ * their natural content width. Font styles are copied from the source table so
+ * text measures identically even if `document.body` styles differ.
+ */
+function createMeasurementContainer(sourceTable: HTMLTableElement): { container: HTMLDivElement; tbody: HTMLTableSectionElement; table: HTMLTableElement } {
+  const container = document.createElement('div');
+  container.style.position = 'absolute';
+  container.style.top = '0';
+  container.style.left = '-99999px';
+  container.style.visibility = 'hidden';
+  container.style.pointerEvents = 'none';
+  container.style.width = 'max-content';
+  container.setAttribute('aria-hidden', 'true');
+
+  const table = document.createElement('table');
+  const sourceStyle = window.getComputedStyle(sourceTable);
+  table.style.tableLayout = 'auto';
+  table.style.width = 'auto';
+  table.style.borderCollapse = sourceStyle.borderCollapse;
+  table.style.fontFamily = sourceStyle.fontFamily;
+  table.style.fontSize = sourceStyle.fontSize;
+  table.style.lineHeight = sourceStyle.lineHeight;
+
+  const tbody = document.createElement('tbody');
+  table.appendChild(tbody);
+  container.appendChild(table);
+
+  return { container, tbody, table };
+}
+
+/**
+ * Clones a cell into its own measurement row, neutralizing anything that would
+ * hide the content's true width (fixed widths, truncation, wrapping, ids).
+ */
+function appendCellCloneForMeasurement(tbody: HTMLTableSectionElement, cell: HTMLTableCellElement): void {
+  const row = document.createElement('tr');
+  const clone = cell.cloneNode(true) as HTMLTableCellElement;
+
+  clone.style.width = 'auto';
+  clone.style.minWidth = '0';
+  clone.style.maxWidth = 'none';
+  clone.style.position = 'static';
+  clone.style.whiteSpace = 'nowrap';
+  clone.removeAttribute('id');
+
+  // Force single-line rendering on descendants so truncated/wrapped text
+  // contributes its full width, and strip duplicate ids from the document.
+  for (const descendant of clone.querySelectorAll<HTMLElement>('*')) {
+    descendant.style.whiteSpace = 'nowrap';
+    descendant.removeAttribute('id');
+  }
+
+  row.appendChild(clone);
+  tbody.appendChild(row);
+}
+
+/**
+ * Measures the width (px) a column needs to fully display the content of its
+ * currently rendered cells, clamped to the provided min/max.
+ *
+ * @param headerCell - The column's `<th>` element (e.g. resolved from a resize handle via `closest('th')`).
+ * @returns The clamped ideal width, or `null` when measurement is impossible
+ *          (detached header cell / no owning table / nothing to measure).
+ */
+export function measureColumnAutoWidth(headerCell: HTMLTableCellElement, options: MeasureColumnAutoWidthOptions = {}): number | null {
+  const {
+    minWidth = DEFAULT_MIN_WIDTH,
+    maxWidth = DEFAULT_MAX_WIDTH,
+    extraPadding = DEFAULT_EXTRA_PADDING,
+    includeHeader = true,
+    maxRowsToMeasure = DEFAULT_MAX_ROWS_TO_MEASURE,
+  } = options;
+
+  const sourceTable: HTMLTableElement | null = headerCell.closest('table');
+  const cells = collectColumnCells(headerCell, includeHeader, maxRowsToMeasure);
+
+  if (!sourceTable || cells.length === 0) {
+    return null;
+  }
+
+  const { container, tbody, table } = createMeasurementContainer(sourceTable);
+
+  try {
+    for (const cell of cells) {
+      appendCellCloneForMeasurement(tbody, cell);
+    }
+
+    document.body.appendChild(container);
+    const measuredWidth = Math.ceil(table.getBoundingClientRect().width);
+
+    return Math.min(maxWidth, Math.max(minWidth, measuredWidth + extraPadding));
+  } finally {
+    container.remove();
+  }
+}

--- a/shared/table-auto-width/useAutoColumnWidth.ts
+++ b/shared/table-auto-width/useAutoColumnWidth.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { measureColumnAutoWidth } from './tableAutoWidth.utils';
+
+export interface UseAutoColumnWidthOptions {
+  /** Identifier for the column being auto-sized, forwarded to onWidthChange. */
+  columnId: string;
+  /** Minimum allowed width in px. @default 80 */
+  minWidth?: number;
+  /** Maximum allowed width in px. @default 1200 */
+  maxWidth?: number;
+  /** Extra px added on top of the measured content width for breathing room. @default 16 */
+  extraPadding?: number;
+  /** Whether the header cell's own content participates in the measurement. @default true */
+  includeHeader?: boolean;
+  /** Safety cap on how many body rows are measured, for very large tables. @default 200 */
+  maxRowsToMeasure?: number;
+  /** Called with the measured width so the consumer can persist it (e.g. a zustand table store). */
+  onWidthChange: (_columnId: string, _width: number) => void;
+}
+
+/**
+ * Auto-fits a table column's width to its currently rendered content on double click.
+ *
+ * Composable and dataset-agnostic: the hook knows nothing about the data — it
+ * resolves the column's `<th>` from the double-clicked element (`closest('th')`),
+ * measures the rendered cells in that column position via
+ * `measureColumnAutoWidth`, and hands the resulting width to `onWidthChange`
+ * for the consumer to persist however it likes (zustand, URL state, server…).
+ *
+ * Usage: attach the returned `handleAutoFitDoubleClick` to the `onDoubleClick`
+ * of any element rendered inside the column's header cell (typically the
+ * column's resize handle).
+ *
+ * Infinite scrolling note: only cells present in the DOM are measured, so the
+ * column auto-fits to what is currently loaded/on screen.
+ */
+export default function useAutoColumnWidth({
+  columnId,
+  minWidth,
+  maxWidth,
+  extraPadding,
+  includeHeader,
+  maxRowsToMeasure,
+  onWidthChange,
+}: UseAutoColumnWidthOptions) {
+  /** Attach to the resize handle's onDoubleClick to auto-fit the column to its content. */
+  const handleAutoFitDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      e.preventDefault();
+
+      const headerCell: HTMLTableCellElement | null = e.currentTarget.closest('th');
+      if (!headerCell) {
+        return;
+      }
+
+      const autoWidth = measureColumnAutoWidth(headerCell, { minWidth, maxWidth, extraPadding, includeHeader, maxRowsToMeasure });
+      if (autoWidth === null) {
+        return;
+      }
+
+      onWidthChange(columnId, autoWidth);
+    },
+    [columnId, minWidth, maxWidth, extraPadding, includeHeader, maxRowsToMeasure, onWidthChange],
+  );
+
+  return {
+    /** Double-click handler to attach to the column's resize handle element. */
+    handleAutoFitDoubleClick,
+  };
+}

--- a/shared/table/BillsDueTable.tsx
+++ b/shared/table/BillsDueTable.tsx
@@ -37,6 +37,7 @@ export default function BillsDueTable({ billDues, columns, sortData, pageId, tab
                 sortData={ sortData }
                 pageId={ pageId }
                 sortable={ unsortableBillsColumns[column] ?? true }
+                hideRightBorder={ index === columns.length - 1 }
                 onSortUpdate={ handleOnSortUpdate }
               />
             );

--- a/shared/table/BillsDueTable.tsx
+++ b/shared/table/BillsDueTable.tsx
@@ -37,7 +37,6 @@ export default function BillsDueTable({ billDues, columns, sortData, pageId, tab
                 sortData={ sortData }
                 pageId={ pageId }
                 sortable={ unsortableBillsColumns[column] ?? true }
-                hideRightBorder={ index === columns.length - 1 }
                 onSortUpdate={ handleOnSortUpdate }
               />
             );

--- a/shared/table/BillsDueTable.tsx
+++ b/shared/table/BillsDueTable.tsx
@@ -8,6 +8,7 @@ import { SortDataModel, SortDataPageId, SortDataUpsertable } from '@/models/sort
 
 import FormattedTableHeader from './FormattedTableHeader';
 import BillsTableParentRow from './BillsDueTableParentRow';
+import FormattedTableHeadFiller from './FormattedTableHeadFiller';
 
 interface BillsDueTableProps {
   billDues: BillDueWithSubscription[];
@@ -26,14 +27,13 @@ export default function BillsDueTable({ billDues, columns, sortData, pageId, tab
     <Table className="table-fixed" id={ tableId ?? 'bills-table' }>
       <TableHeader className={ `bg-muted` }>
         <TableRow className="hover:bg-transparent">
-          { columns.map((column: string, index: number, array: string[]) => {
+          { columns.map((column: string, index: number) => {
             return (
               <FormattedTableHeader
                 tableId="bills"
                 key={ column }
                 columnId={ column }
                 index={ index }
-                length={ array.length }
                 sortData={ sortData }
                 pageId={ pageId }
                 sortable={ unsortableBillsColumns[column] ?? true }
@@ -41,6 +41,7 @@ export default function BillsDueTable({ billDues, columns, sortData, pageId, tab
               />
             );
           }) }
+          <FormattedTableHeadFiller />
         </TableRow>
       </TableHeader>
       <TableBody>

--- a/shared/table/FormattedTableCell.tsx
+++ b/shared/table/FormattedTableCell.tsx
@@ -9,7 +9,9 @@ type FormattedTableCellProps = React.ComponentProps<typeof TableCell> & {
 export default function FormattedTableCell({ isSticky, showVerticalBorder, className, ...props }: FormattedTableCellProps) {
   return (
     <TableCell
-      className={ cn(className, {
+      // A cell directly followed by the filler column is the row's last data cell — its right
+      // border is dropped automatically so no stray line runs down the body of the table.
+      className={ cn('[&:has(+[data-table-filler])]:border-r-0', className, {
         'sticky left-0 z-10 bg-card after:pointer-events-none after:absolute after:top-0 after:right-0 after:h-full after:w-px after:bg-border':
           isSticky,
         'border-r border-border': showVerticalBorder && !isSticky,

--- a/shared/table/FormattedTableCellFiller.tsx
+++ b/shared/table/FormattedTableCellFiller.tsx
@@ -12,5 +12,5 @@ type FormattedTableCellFillerProps = {
  * last data column.
  */
 export default function FormattedTableCellFiller({ className }: FormattedTableCellFillerProps) {
-  return <TableCell aria-hidden="true" data-table-filler="true" className={ cn(className) } />;
+  return <TableCell aria-hidden="true" className={ cn(className) } />;
 }

--- a/shared/table/FormattedTableCellFiller.tsx
+++ b/shared/table/FormattedTableCellFiller.tsx
@@ -12,5 +12,5 @@ type FormattedTableCellFillerProps = {
  * last data column.
  */
 export default function FormattedTableCellFiller({ className }: FormattedTableCellFillerProps) {
-  return <TableCell aria-hidden="true" className={ cn(className) } />;
+  return <TableCell aria-hidden="true" data-table-filler="true" className={ cn(className) } />;
 }

--- a/shared/table/FormattedTableCellFiller.tsx
+++ b/shared/table/FormattedTableCellFiller.tsx
@@ -10,7 +10,10 @@ type FormattedTableCellFillerProps = {
  * the `<FormattedTableHeadFiller />` column in the header so leftover
  * horizontal space is absorbed by an empty column instead of stretching the
  * last data column.
+ *
+ * The `data-table-filler` attribute lets the preceding data cell detect the
+ * filler and automatically drop its right border (see `FormattedTableCell`).
  */
 export default function FormattedTableCellFiller({ className }: FormattedTableCellFillerProps) {
-  return <TableCell aria-hidden="true" className={ cn(className) } />;
+  return <TableCell aria-hidden="true" data-table-filler="true" className={ cn(className) } />;
 }

--- a/shared/table/FormattedTableCellFiller.tsx
+++ b/shared/table/FormattedTableCellFiller.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/utils';
+import { TableCell } from '@/components/ui/table';
+
+type FormattedTableCellFillerProps = {
+  className?: string;
+};
+
+/**
+ * Zero-content body cell appended after the last data cell of a row, matching
+ * the `<FormattedTableHeadFiller />` column in the header so leftover
+ * horizontal space is absorbed by an empty column instead of stretching the
+ * last data column.
+ */
+export default function FormattedTableCellFiller({ className }: FormattedTableCellFillerProps) {
+  return <TableCell aria-hidden="true" className={ cn(className) } />;
+}

--- a/shared/table/FormattedTableHead.tsx
+++ b/shared/table/FormattedTableHead.tsx
@@ -12,12 +12,6 @@ type FormattedTableHeadProps = {
   index: number;
   isResizing: boolean;
   currentWidth: number;
-  /**
-   * Force-hides the column's right border. The border already hides automatically when a
-   * `<FormattedTableHeadFiller />` directly follows this column — this prop is only needed
-   * for tables without a filler column.
-   */
-  hideRightBorder?: boolean;
   children: React.ReactNode;
 };
 
@@ -28,17 +22,16 @@ export default function FormattedTableHead({
   index,
   isResizing,
   currentWidth,
-  hideRightBorder,
   children,
 }: FormattedTableHeadProps) {
   return (
     <TableHead
       ref={ ref }
       { ...draggableProps }
-      className={ cn('relative truncate [&:has(+[data-table-filler])]:border-r-0', {
+      className={ cn('relative truncate', {
         'sticky left-0 z-20 rounded-tl-md bg-muted after:pointer-events-none after:absolute after:top-0 after:right-0 after:h-full after:w-px after:bg-foreground/20':
           index === 0,
-        'border-r border-foreground/30': index !== 0 && !hideRightBorder,
+        'border-r border-foreground/30': index !== 0,
         'bg-accent': isResizing,
         'bg-accent shadow-md': isDragging,
       }) }

--- a/shared/table/FormattedTableHead.tsx
+++ b/shared/table/FormattedTableHead.tsx
@@ -12,6 +12,8 @@ type FormattedTableHeadProps = {
   index: number;
   isResizing: boolean;
   currentWidth: number;
+  /** Hides the column's right border — e.g. for the last data column, so no stray line shows against the filler column. */
+  hideRightBorder?: boolean;
   children: React.ReactNode;
 };
 
@@ -22,6 +24,7 @@ export default function FormattedTableHead({
   index,
   isResizing,
   currentWidth,
+  hideRightBorder,
   children,
 }: FormattedTableHeadProps) {
   return (
@@ -31,7 +34,7 @@ export default function FormattedTableHead({
       className={ cn('relative truncate', {
         'sticky left-0 z-20 rounded-tl-md bg-muted after:pointer-events-none after:absolute after:top-0 after:right-0 after:h-full after:w-px after:bg-foreground/20':
           index === 0,
-        'border-r border-foreground/30': index !== 0,
+        'border-r border-foreground/30': index !== 0 && !hideRightBorder,
         'bg-accent': isResizing,
         'bg-accent shadow-md': isDragging,
       }) }

--- a/shared/table/FormattedTableHead.tsx
+++ b/shared/table/FormattedTableHead.tsx
@@ -12,7 +12,11 @@ type FormattedTableHeadProps = {
   index: number;
   isResizing: boolean;
   currentWidth: number;
-  /** Hides the column's right border — e.g. for the last data column, so no stray line shows against the filler column. */
+  /**
+   * Force-hides the column's right border. The border already hides automatically when a
+   * `<FormattedTableHeadFiller />` directly follows this column — this prop is only needed
+   * for tables without a filler column.
+   */
   hideRightBorder?: boolean;
   children: React.ReactNode;
 };
@@ -31,7 +35,7 @@ export default function FormattedTableHead({
     <TableHead
       ref={ ref }
       { ...draggableProps }
-      className={ cn('relative truncate', {
+      className={ cn('relative truncate [&:has(+[data-table-filler])]:border-r-0', {
         'sticky left-0 z-20 rounded-tl-md bg-muted after:pointer-events-none after:absolute after:top-0 after:right-0 after:h-full after:w-px after:bg-foreground/20':
           index === 0,
         'border-r border-foreground/30': index !== 0 && !hideRightBorder,

--- a/shared/table/FormattedTableHead.tsx
+++ b/shared/table/FormattedTableHead.tsx
@@ -10,7 +10,6 @@ type FormattedTableHeadProps = {
   draggableProps?: DraggableProvidedDraggableProps;
   isDragging?: boolean;
   index: number;
-  isLastColumn: boolean;
   isResizing: boolean;
   currentWidth: number;
   children: React.ReactNode;
@@ -21,7 +20,6 @@ export default function FormattedTableHead({
   draggableProps,
   isDragging,
   index,
-  isLastColumn,
   isResizing,
   currentWidth,
   children,
@@ -33,13 +31,12 @@ export default function FormattedTableHead({
       className={ cn('relative truncate', {
         'sticky left-0 z-20 rounded-tl-md bg-muted after:pointer-events-none after:absolute after:top-0 after:right-0 after:h-full after:w-px after:bg-foreground/20':
           index === 0,
-        'rounded-tr-md': isLastColumn,
-        'border-r border-foreground/30': !isLastColumn && index !== 0,
+        'border-r border-foreground/30': index !== 0,
         'bg-accent': isResizing,
         'bg-accent shadow-md': isDragging,
       }) }
       style={ {
-        width: isLastColumn ? '100%' : `${currentWidth}px`,
+        width: `${currentWidth}px`,
         ...draggableProps?.style,
       } }
     >

--- a/shared/table/FormattedTableHeadFiller.tsx
+++ b/shared/table/FormattedTableHeadFiller.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/lib/utils';
+import { TableHead } from '@/components/ui/table';
+
+type FormattedTableHeadFillerProps = {
+  className?: string;
+};
+
+/**
+ * Zero-content header cell appended after the last data column.
+ *
+ * Under `table-fixed` it carries no width, so it absorbs whatever horizontal
+ * space is left when the table is stretched to fill its container
+ * (`minWidth: 100%`). This keeps every data column — including the last one —
+ * at its stored px width instead of the last column stretching to fill the
+ * section. When the columns overflow and the table scrolls horizontally, the
+ * filler collapses to zero width.
+ *
+ * Pair with `<FormattedTableCellFiller />` appended to each body row so the
+ * column structure matches between header and body.
+ */
+export default function FormattedTableHeadFiller({ className }: FormattedTableHeadFillerProps) {
+  return <TableHead aria-hidden="true" className={ cn('rounded-tr-md', className) } />;
+}

--- a/shared/table/FormattedTableHeadFiller.tsx
+++ b/shared/table/FormattedTableHeadFiller.tsx
@@ -19,5 +19,5 @@ type FormattedTableHeadFillerProps = {
  * column structure matches between header and body.
  */
 export default function FormattedTableHeadFiller({ className }: FormattedTableHeadFillerProps) {
-  return <TableHead aria-hidden="true" className={ cn('rounded-tr-md', className) } />;
+  return <TableHead aria-hidden="true" data-table-filler="true" className={ cn('rounded-tr-md', className) } />;
 }

--- a/shared/table/FormattedTableHeadFiller.tsx
+++ b/shared/table/FormattedTableHeadFiller.tsx
@@ -19,5 +19,5 @@ type FormattedTableHeadFillerProps = {
  * column structure matches between header and body.
  */
 export default function FormattedTableHeadFiller({ className }: FormattedTableHeadFillerProps) {
-  return <TableHead aria-hidden="true" data-table-filler="true" className={ cn('rounded-tr-md', className) } />;
+  return <TableHead aria-hidden="true" className={ cn('rounded-tr-md', className) } />;
 }

--- a/shared/table/FormattedTableHeadResizeHandle.tsx
+++ b/shared/table/FormattedTableHeadResizeHandle.tsx
@@ -4,12 +4,14 @@ import WithTooltip from '../components/WithTooltip';
 
 type FormattedTableHeadResizeHandleProps = {
   handleResizePointerDown: (_e: React.PointerEvent) => void;
+  handleResizeDoubleClick?: (_e: React.MouseEvent<HTMLElement>) => void;
   isResizing: boolean;
   isLastColumn?: boolean;
 };
 
 export default function FormattedTableHeadResizeHandle({
   handleResizePointerDown,
+  handleResizeDoubleClick,
   isResizing,
   isLastColumn,
 }: FormattedTableHeadResizeHandleProps) {
@@ -18,9 +20,10 @@ export default function FormattedTableHeadResizeHandle({
   }
 
   return (
-    <WithTooltip tooltip="Resize column">
+    <WithTooltip tooltip={ handleResizeDoubleClick ? 'Drag to resize. Double click to auto fit.' : 'Resize column' }>
       <div
         onPointerDown={ handleResizePointerDown }
+        onDoubleClick={ handleResizeDoubleClick }
         className={ cn(`
           absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize
           hover:bg-accent

--- a/shared/table/FormattedTableHeadResizeHandle.tsx
+++ b/shared/table/FormattedTableHeadResizeHandle.tsx
@@ -6,19 +6,13 @@ type FormattedTableHeadResizeHandleProps = {
   handleResizePointerDown: (_e: React.PointerEvent) => void;
   handleResizeDoubleClick?: (_e: React.MouseEvent<HTMLElement>) => void;
   isResizing: boolean;
-  isLastColumn?: boolean;
 };
 
 export default function FormattedTableHeadResizeHandle({
   handleResizePointerDown,
   handleResizeDoubleClick,
   isResizing,
-  isLastColumn,
 }: FormattedTableHeadResizeHandleProps) {
-  if (isLastColumn) {
-    return null;
-  }
-
   return (
     <WithTooltip tooltip={ handleResizeDoubleClick ? 'Drag to resize. Double click to auto fit.' : 'Resize column' }>
       <div

--- a/shared/table/FormattedTableHeader.tsx
+++ b/shared/table/FormattedTableHeader.tsx
@@ -59,7 +59,7 @@ export default function FormattedTableHeader({
   const [isPending, startTransition] = useTransition();
   const columnWidth = useTableColumn(columnId);
   const { setColumnWidth } = useTableColumnsActions();
-  const { currentWidth, isResizing, handleResizePointerDown } = useColumnResize({
+  const { currentWidth, isResizing, handleResizePointerDown, handleResizeDoubleClick } = useColumnResize({
     columnId,
     initialWidth: columnWidth,
     minWidth: 80,
@@ -147,6 +147,7 @@ export default function FormattedTableHeader({
       </RowStack>
       <FormattedTableHeadResizeHandle
         handleResizePointerDown={ handleResizePointerDown }
+        handleResizeDoubleClick={ handleResizeDoubleClick }
         isResizing={ isResizing }
         isLastColumn={ isLastColumn }
       />

--- a/shared/table/FormattedTableHeader.tsx
+++ b/shared/table/FormattedTableHeader.tsx
@@ -38,6 +38,8 @@ interface FormattedTableHeaderProps {
   draggableProps?: DraggableProvidedDraggableProps;
   dragHandleProps?: DraggableProvidedDragHandleProps | null;
   isDragging?: boolean;
+  /** Hides the column's right border — pass for the last data column so no stray line shows against the filler column. */
+  hideRightBorder?: boolean;
   onSortUpdate?: (_sortData: SortDataUpsertable) => void;
 }
 
@@ -52,6 +54,7 @@ export default function FormattedTableHeader({
   draggableProps,
   dragHandleProps,
   isDragging,
+  hideRightBorder,
   onSortUpdate,
 }: FormattedTableHeaderProps) {
   const [isPending, startTransition] = useTransition();
@@ -110,6 +113,7 @@ export default function FormattedTableHeader({
       isDragging={ isDragging }
       index={ index }
       isResizing={ isResizing }
+      hideRightBorder={ hideRightBorder }
     >
       <RowStack className={ cn('group/header flex flex-row items-center justify-start select-none') } id={ `table-header-content-${columnId}` }>
         <FormattedTableHeadDragHandle dragHandleProps={ dragHandleProps } />

--- a/shared/table/FormattedTableHeader.tsx
+++ b/shared/table/FormattedTableHeader.tsx
@@ -30,7 +30,6 @@ import FormattedTableHeadResizeHandle from './FormattedTableHeadResizeHandle';
 interface FormattedTableHeaderProps {
   columnId: string;
   index: number;
-  length: number;
   sortData: SortDataModel | null;
   pageId: SortDataPageId;
   sortable?: boolean;
@@ -45,7 +44,6 @@ interface FormattedTableHeaderProps {
 export default function FormattedTableHeader({
   columnId,
   index,
-  length,
   sortData,
   pageId,
   sortable,
@@ -82,7 +80,6 @@ export default function FormattedTableHeader({
   const nextSortData: SortData = getNextSortDirection(optimisticSortData, columnId as SortField);
   const isColumnSorted: boolean = optimisticSortData.sort === columnId && optimisticSortData.direction !== '';
   const sortDirection: string | undefined = optimisticSortData.direction;
-  const isLastColumn = index === length - 1;
   const columnSortTooltip: string = getSortInfoText(columnId, !!sortable, isColumnSorted, sortDirection as SortDirection, nextSortData);
   const showFilterOptions = getIsColumnFilterable(columnId as AppColumnId);
 
@@ -112,7 +109,6 @@ export default function FormattedTableHeader({
       currentWidth={ currentWidth }
       isDragging={ isDragging }
       index={ index }
-      isLastColumn={ isLastColumn }
       isResizing={ isResizing }
     >
       <RowStack className={ cn('group/header flex flex-row items-center justify-start select-none') } id={ `table-header-content-${columnId}` }>
@@ -149,7 +145,6 @@ export default function FormattedTableHeader({
         handleResizePointerDown={ handleResizePointerDown }
         handleResizeDoubleClick={ handleResizeDoubleClick }
         isResizing={ isResizing }
-        isLastColumn={ isLastColumn }
       />
     </FormattedTableHead>
   );

--- a/shared/table/FormattedTableHeader.tsx
+++ b/shared/table/FormattedTableHeader.tsx
@@ -38,11 +38,6 @@ interface FormattedTableHeaderProps {
   draggableProps?: DraggableProvidedDraggableProps;
   dragHandleProps?: DraggableProvidedDragHandleProps | null;
   isDragging?: boolean;
-  /**
-   * Force-hides the column's right border. Not needed when a `<FormattedTableHeadFiller />`
-   * directly follows this column — the border hides automatically in that case.
-   */
-  hideRightBorder?: boolean;
   onSortUpdate?: (_sortData: SortDataUpsertable) => void;
 }
 
@@ -57,7 +52,6 @@ export default function FormattedTableHeader({
   draggableProps,
   dragHandleProps,
   isDragging,
-  hideRightBorder,
   onSortUpdate,
 }: FormattedTableHeaderProps) {
   const [isPending, startTransition] = useTransition();
@@ -116,7 +110,6 @@ export default function FormattedTableHeader({
       isDragging={ isDragging }
       index={ index }
       isResizing={ isResizing }
-      hideRightBorder={ hideRightBorder }
     >
       <RowStack className={ cn('group/header flex flex-row items-center justify-start select-none') } id={ `table-header-content-${columnId}` }>
         <FormattedTableHeadDragHandle dragHandleProps={ dragHandleProps } />

--- a/shared/table/FormattedTableHeader.tsx
+++ b/shared/table/FormattedTableHeader.tsx
@@ -38,7 +38,10 @@ interface FormattedTableHeaderProps {
   draggableProps?: DraggableProvidedDraggableProps;
   dragHandleProps?: DraggableProvidedDragHandleProps | null;
   isDragging?: boolean;
-  /** Hides the column's right border — pass for the last data column so no stray line shows against the filler column. */
+  /**
+   * Force-hides the column's right border. Not needed when a `<FormattedTableHeadFiller />`
+   * directly follows this column — the border hides automatically in that case.
+   */
   hideRightBorder?: boolean;
   onSortUpdate?: (_sortData: SortDataUpsertable) => void;
 }

--- a/shared/table/SearchTableHeaderDisplay.tsx
+++ b/shared/table/SearchTableHeaderDisplay.tsx
@@ -52,7 +52,7 @@ export default function SearchTableHeaderDisplay({
   const [isPending, startTransition] = useTransition();
   const columnWidth = useTableColumn(columnId);
   const { setColumnWidth } = useTableColumnsActions();
-  const { currentWidth, isResizing, handleResizePointerDown } = useColumnResize({
+  const { currentWidth, isResizing, handleResizePointerDown, handleResizeDoubleClick } = useColumnResize({
     columnId,
     initialWidth: columnWidth,
     minWidth: 80,
@@ -176,9 +176,10 @@ export default function SearchTableHeaderDisplay({
         </RowStack>
       </RowStack>
       { !isLastColumn && (
-        <WithTooltip tooltip="Resize column">
+        <WithTooltip tooltip="Drag to resize. Double click to auto fit.">
           <div
             onPointerDown={ handleResizePointerDown }
+            onDoubleClick={ handleResizeDoubleClick }
             className={ cn(`
               absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize
               hover:bg-accent

--- a/shared/table/SearchTableHeaderDisplay.tsx
+++ b/shared/table/SearchTableHeaderDisplay.tsx
@@ -75,7 +75,6 @@ export default function SearchTableHeaderDisplay({
   const nextSortData: SortData = getNextSortDirection(optimisticSortData, columnId as SortField);
   const isColumnSorted: boolean = optimisticSortData.sort === columnId && optimisticSortData.direction !== '';
   const sortDirection: string | undefined = optimisticSortData.direction;
-  const isLastColumn = index === length - 1;
   const columnSortTooltip: string = getSortInfoText(columnId, !!sortable, isColumnSorted, sortDirection as SortDirection, nextSortData);
 
   const handleOnHeaderClick = (columnId: string) => {
@@ -103,13 +102,12 @@ export default function SearchTableHeaderDisplay({
       { ...draggableProps }
       className={ cn('relative truncate', {
         'sticky left-0 z-20 rounded-tl-md bg-muted': index === 0,
-        'rounded-tr-md': isLastColumn,
         'border-l border-border': index !== 0,
         'bg-accent': isResizing,
         'bg-accent shadow-md': isDragging,
       }) }
       style={ {
-        width: isLastColumn ? '100%' : `${currentWidth}px`,
+        width: `${currentWidth}px`,
         ...draggableProps?.style,
       } }
     >
@@ -175,18 +173,16 @@ export default function SearchTableHeaderDisplay({
           : null }
         </RowStack>
       </RowStack>
-      { !isLastColumn && (
-        <WithTooltip tooltip="Drag to resize. Double click to auto fit.">
-          <div
-            onPointerDown={ handleResizePointerDown }
-            onDoubleClick={ handleResizeDoubleClick }
-            className={ cn(`
-              absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize
-              hover:bg-accent
-            `, { 'bg-accent': isResizing }) }
-          />
-        </WithTooltip>
-      ) }
+      <WithTooltip tooltip="Drag to resize. Double click to auto fit.">
+        <div
+          onPointerDown={ handleResizePointerDown }
+          onDoubleClick={ handleResizeDoubleClick }
+          className={ cn(`
+            absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize
+            hover:bg-accent
+          `, { 'bg-accent': isResizing }) }
+        />
+      </WithTooltip>
     </TableHead>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add double-click auto-fit for column widths and stop the last column from stretching by adding a hidden filler column. Columns size to visible content and persist like drag-resize; the last column keeps its saved width, is resizable, and the header shows its right border while the body hides it at the table edge.

- New Features
  - Added portable `shared/table-auto-width` module: `tableAutoWidth.utils.ts` measures the widest visible content by cloning column cells into an off-screen table; `useAutoColumnWidth.ts` returns `handleAutoFitDoubleClick` and reports the width via `onWidthChange`.
  - Composed into `useColumnResize` (`handleResizeDoubleClick`) and wired to resize handles with updated tooltips. Measures only visible rows (header included), clamps to min/max, adds padding, and persists via existing `setColumnWidth`.

- Bug Fixes
  - Prevented last column from auto-stretching with `FormattedTableHeadFiller` and `FormattedTableCellFiller`; removed last-column special-casing so it resizes normally across bills, subscriptions, subscription details, search, and shared tables.
  - Auto-hide the right border on the last body cell when it precedes the filler; the header keeps its right border (and resize handle).

<sup>Written for commit 3f8646a7d8ae68e68b2c6663bcc6eba91d9fbc7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yiqu/tb/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

